### PR TITLE
Fix leaking the janitor ticker when shutting down

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -941,12 +941,13 @@ type janitor struct {
 
 func (j *janitor) Run(c *cache) {
 	j.stop = make(chan bool)
-	tick := time.Tick(j.Interval)
+	ticker := time.NewTicker(j.Interval)
 	for {
 		select {
-		case <-tick:
+		case <-ticker.C:
 			c.DeleteExpired()
 		case <-j.stop:
+			ticker.Stop()
 			return
 		}
 	}


### PR DESCRIPTION
The documentation on `time.Tick` says:
> While Tick is useful for clients that have no need to shut down the Ticker, be aware that without a way to shut it down the underlying Ticker cannot be recovered by the garbage collector; it "leaks".